### PR TITLE
Remove extraneous time-based difference check

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -192,8 +192,9 @@ func run() int {
 		alertEtcdPrefix      = kingpin.Flag("alerts.etcd.prefix", "String prefix for storing AM alerts in etc").Default("am/alerts-").String()
 		etcdTimeoutGet       = kingpin.Flag("etcd.timeout.get", "Timeout for GET from etcd").Default("150ms").Duration()
 		etcdTimeoutPut       = kingpin.Flag("etcd.timeout.put", "Timeout for PUT to etcd").Default("250ms").Duration()
-		etcdDelayRunLoop     = kingpin.Flag("etcd.delay.run-loop", "Delay before running the etcd run-loop after startup").Default("15s").Duration()
-		etcdRetryFailureGet  = kingpin.Flag("etcd.retry.get", "Delay before retrying etcd GET failure").Default("5s").Duration()
+		etcdTimeoutDel       = kingpin.Flag("etcd.timeout.del", "Timeout for DEL to etcd").Default("250ms").Duration()
+		etcdDelayRunLoop     = kingpin.Flag("etcd.delay.run-loop", "Delay before running etcd run-loops after startup").Default("10s").Duration()
+		etcdRetryFailureLoad = kingpin.Flag("etcd.retry.load", "Delay before retrying failures of loading all alerts from etcd").Default("5s").Duration()
 
 		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
 		routePrefix    = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").String()
@@ -335,7 +336,7 @@ func run() int {
 			return 1
 		}
 	} else if *alertStorageProvider == "etcd" {
-		etcdAlerts, err := etcd.NewAlerts(context.Background(), marker, *alertGCInterval, logger, *alertEtcdEndpoints, *alertEtcdPrefix, *etcdTimeoutGet, *etcdTimeoutPut, *etcdRetryFailureGet)
+		etcdAlerts, err := etcd.NewAlerts(context.Background(), marker, *alertGCInterval, logger, *alertEtcdEndpoints, *alertEtcdPrefix, *etcdTimeoutGet, *etcdTimeoutPut, *etcdTimeoutDel, *etcdRetryFailureLoad)
 		if err != nil {
 			level.Error(logger).Log("err", err)
 			return 1

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -194,7 +194,6 @@ func run() int {
 		etcdTimeoutPut       = kingpin.Flag("etcd.timeout.put", "Timeout for PUT to etcd").Default("250ms").Duration()
 		etcdDelayRunLoop     = kingpin.Flag("etcd.delay.run-loop", "Delay before running the etcd run-loop after startup").Default("15s").Duration()
 		etcdRetryFailureGet  = kingpin.Flag("etcd.retry.get", "Delay before retrying etcd GET failure").Default("5s").Duration()
-		etcdAlertSigDiff     = kingpin.Flag("etcd.alert.sig-time-diff", "The amount of time between a received alert's StartsAt one already in etcd that triggers and update").Default("30s").Duration()
 
 		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
 		routePrefix    = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").String()
@@ -336,7 +335,7 @@ func run() int {
 			return 1
 		}
 	} else if *alertStorageProvider == "etcd" {
-		etcdAlerts, err := etcd.NewAlerts(context.Background(), marker, *alertGCInterval, logger, *alertEtcdEndpoints, *alertEtcdPrefix, *etcdTimeoutGet, *etcdTimeoutPut, *etcdRetryFailureGet, *etcdAlertSigDiff)
+		etcdAlerts, err := etcd.NewAlerts(context.Background(), marker, *alertGCInterval, logger, *alertEtcdEndpoints, *alertEtcdPrefix, *etcdTimeoutGet, *etcdTimeoutPut, *etcdRetryFailureGet)
 		if err != nil {
 			level.Error(logger).Log("err", err)
 			return 1

--- a/provider/etcd/etcd.go
+++ b/provider/etcd/etcd.go
@@ -50,7 +50,7 @@ type listeningAlerts struct {
 
 // NewAlerts returns a new alert provider.
 func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l log.Logger,
-	etcdEndpoints []string, etcdPrefix string, timeoutGet time.Duration, timeoutPut time.Duration, retryFailureGet time.Duration) (*Alerts, error) {
+	etcdEndpoints []string, etcdPrefix string, timeoutGet time.Duration, timeoutPut time.Duration, timeoutDel time.Duration, retryFailureLoad time.Duration) (*Alerts, error) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	a := &Alerts{
@@ -85,7 +85,7 @@ func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l 
 	a.alerts.Run(ctx, intervalGC)
 
 	// initialize etcd client
-	etcdClient, err := NewEtcdClient(ctx, a, etcdEndpoints, etcdPrefix, timeoutGet, timeoutPut, retryFailureGet)
+	etcdClient, err := NewEtcdClient(ctx, a, etcdEndpoints, etcdPrefix, timeoutGet, timeoutPut, timeoutDel, retryFailureLoad)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/etcd/etcd.go
+++ b/provider/etcd/etcd.go
@@ -50,7 +50,7 @@ type listeningAlerts struct {
 
 // NewAlerts returns a new alert provider.
 func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l log.Logger,
-	etcdEndpoints []string, etcdPrefix string, timeoutGet time.Duration, timeoutPut time.Duration, retryFailureGet time.Duration, alertSigDiff time.Duration) (*Alerts, error) {
+	etcdEndpoints []string, etcdPrefix string, timeoutGet time.Duration, timeoutPut time.Duration, retryFailureGet time.Duration) (*Alerts, error) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	a := &Alerts{
@@ -85,7 +85,7 @@ func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l 
 	a.alerts.Run(ctx, intervalGC)
 
 	// initialize etcd client
-	etcdClient, err := NewEtcdClient(ctx, a, etcdEndpoints, etcdPrefix, timeoutGet, timeoutPut, retryFailureGet, alertSigDiff)
+	etcdClient, err := NewEtcdClient(ctx, a, etcdEndpoints, etcdPrefix, timeoutGet, timeoutPut, retryFailureGet)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +175,7 @@ func (a *Alerts) put(fromEtcd bool, alerts ...*types.Alert) error {
 		// Check that there's an alert existing within the store before
 		// trying to merge.
 		var old *types.Alert
-		var err error
-		if old, err = a.alerts.Get(fp); err == nil {
+		if old, err := a.alerts.Get(fp); err == nil {
 			// Merge alerts if there is an overlap in activity range.
 			if (alert.EndsAt.After(old.StartsAt) && alert.EndsAt.Before(old.EndsAt)) ||
 				(alert.StartsAt.After(old.StartsAt) && alert.StartsAt.Before(old.EndsAt)) {

--- a/provider/etcd/etcd_client_test.go
+++ b/provider/etcd/etcd_client_test.go
@@ -38,11 +38,11 @@ var (
 	etcdPrefix      = "am/test/alerts-"
 	alertGcInterval = 200 * time.Millisecond
 
-	etcdLogger          log.Logger
-	etcdTimeoutGet      = 150 * time.Millisecond
-	etcdTimeoutPut      = 250 * time.Millisecond
-	etcdRetryFailureGet = 5 * time.Second
-	etcdAlertSigDiff    = 30 * time.Second
+	etcdLogger           log.Logger
+	etcdTimeoutGet       = 150 * time.Millisecond
+	etcdTimeoutPut       = 250 * time.Millisecond
+	etcdTimeoutDel       = 250 * time.Millisecond
+	etcdRetryFailureLoad = 5 * time.Second
 )
 
 func init() {
@@ -61,7 +61,7 @@ func TestEtcdWriteReadDeleteAlert(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, alertGcInterval, etcdLogger,
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestEtcdRunWatch(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, alertGcInterval, etcdLogger,
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestEtcdRunLoadAllAlerts(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, alertGcInterval, etcdLogger,
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestEtcdGC(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, alertGcInterval, etcdLogger,
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/provider/etcd/etcd_test.go
+++ b/provider/etcd/etcd_test.go
@@ -91,7 +91,7 @@ func TestAlertsSubscribePutStarvation(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger(),
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestAlertsPut(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger(),
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestAlertsSubscribe(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	alerts, err := NewAlerts(ctx, marker, 30*time.Minute, log.NewNopLogger(),
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestAlertsGetPending(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger(),
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestAlertsGC(t *testing.T) {
 
 	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, alertGcInterval, log.NewNopLogger(),
-		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdRetryFailureGet, etcdAlertSigDiff)
+		etcdEndpoints, etcdPrefix, etcdTimeoutGet, etcdTimeoutPut, etcdTimeoutDel, etcdRetryFailureLoad)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* This check was originally meant to optimize and reduce
  writes to Etcd.  Now, it is no longer necessary due to
  other optimizations.

* Renamed etcdRetryFailureGet->etcdDelayRunLoop

* Added cli option for etcdTimeoutDel